### PR TITLE
feat: add user registration endpoint to api-gateway

### DIFF
--- a/services/packages/api-gateway/src/auth/auth.service.ts
+++ b/services/packages/api-gateway/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UserServiceClient } from '../services/user-service.client';
-import { LoginDto, AuthResponseDto } from '../dto/auth.dto';
+import { LoginDto, AuthResponseDto, RegisterDto, RegisterResponseDto } from '../dto/auth.dto';
 
 @Injectable()
 export class AuthService {
@@ -53,6 +53,35 @@ export class AuthService {
         throw error;
       }
       throw new UnauthorizedException('Authentication failed');
+    }
+  }
+
+  async register(registerDto: RegisterDto): Promise<RegisterResponseDto> {
+    try {
+      // Create user via User Service
+      const user = await this.userServiceClient.createUser(
+        registerDto.email,
+        registerDto.password,
+        registerDto.full_name,
+        registerDto.push_token,
+      );
+
+      return {
+        user: {
+          id: user.id,
+          email: user.email,
+          full_name: user.name,
+          is_active: user.is_active || true,
+          created_at: user.created_at || new Date().toISOString(),
+          preferences: {
+            email_enabled: user.preferences.email,
+            push_enabled: user.preferences.push,
+          },
+        },
+      };
+    } catch (error) {
+      this.logger.error('Registration failed', error);
+      throw new UnauthorizedException('Registration failed');
     }
   }
 

--- a/services/packages/api-gateway/src/controllers/auth.controller.ts
+++ b/services/packages/api-gateway/src/controllers/auth.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthService } from '../auth/auth.service';
-import { LoginDto, AuthResponseDto } from '../dto/auth.dto';
+import { LoginDto, AuthResponseDto, RegisterDto, RegisterResponseDto } from '../dto/auth.dto';
 import { Public } from '../decorators/public.decorator';
 @ApiTags('Authentication')
 @Controller('auth')
@@ -20,5 +20,19 @@ export class AuthController {
   @ApiResponse({ status: 401, description: 'Invalid credentials' })
   async login(@Body() loginDto: LoginDto): Promise<AuthResponseDto> {
     return this.authService.login(loginDto);
+  }
+
+  @Public()
+  @Post('register')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Register a new user account' })
+  @ApiResponse({
+    status: 201,
+    description: 'User registered successfully',
+    type: RegisterResponseDto,
+  })
+  @ApiResponse({ status: 409, description: 'User already exists' })
+  async register(@Body() registerDto: RegisterDto): Promise<RegisterResponseDto> {
+    return this.authService.register(registerDto);
   }
 }

--- a/services/packages/api-gateway/src/dto/auth.dto.ts
+++ b/services/packages/api-gateway/src/dto/auth.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({ example: 'user@example.com' })
@@ -35,5 +35,55 @@ export class AuthResponseDto {
     id: string;
     email: string;
     name: string;
+  };
+}
+
+export class RegisterDto {
+  @ApiProperty({ example: 'user@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({ example: 'SecurePass123!' })
+  @IsString()
+  @MinLength(8)
+  @IsNotEmpty()
+  password: string;
+
+  @ApiProperty({ example: 'John Doe' })
+  @IsString()
+  @IsNotEmpty()
+  full_name: string;
+
+  @ApiProperty({ example: 'fcm_token_here', required: false })
+  @IsOptional()
+  @IsString()
+  push_token?: string;
+}
+
+export class RegisterResponseDto {
+  @ApiProperty({
+    example: {
+      id: '123',
+      email: 'user@example.com',
+      full_name: 'John Doe',
+      is_active: true,
+      created_at: '2025-11-11T01:40:44.231Z',
+      preferences: {
+        email_enabled: true,
+        push_enabled: true,
+      },
+    },
+  })
+  user: {
+    id: string;
+    email: string;
+    full_name: string;
+    is_active: boolean;
+    created_at: string;
+    preferences: {
+      email_enabled: boolean;
+      push_enabled: boolean;
+    };
   };
 }

--- a/services/packages/api-gateway/src/services/user-service.client.ts
+++ b/services/packages/api-gateway/src/services/user-service.client.ts
@@ -15,6 +15,8 @@ export interface User {
   email: string;
   push_token?: string;
   preferences: UserPreferences;
+  is_active?: boolean;
+  created_at?: string;
 }
 
 @Injectable()
@@ -140,6 +142,27 @@ export class UserServiceClient {
         error,
       );
       return false; // Default to not allowing if we can't check
+    }
+  }
+
+  async createUser(email: string, password: string, fullName: string, pushToken?: string): Promise<User> {
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(`${this.userServiceUrl}/users/create-account`, {
+          email,
+          password,
+          full_name: fullName,
+          push_token: pushToken,
+        }),
+      );
+
+      return response.data;
+    } catch (error) {
+      this.logger.error(`Failed to create user ${email}`, error);
+      throw new HttpException(
+        'Failed to create user',
+        error.response?.status || HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 }


### PR DESCRIPTION

- Add RegisterDto and RegisterResponseDto to auth DTOs
- Implement createUser method in UserServiceClient
- Add register method to AuthService 
- Add /auth/register endpoint to AuthController
- Update User interface to include is_active and created_at fields
- Fix TypeScript type issues with optional fields

Registration flow now works end-to-end:
- POST /api/v1/auth/register creates user via user-service
- Returns user data with preferences
- Followed by successful login with JWT token generation

All tests passing:
- User creation via api-gateway ✅
- User validation via user-service ✅  
- Login and JWT generation ✅
- Service communication verified ✅
